### PR TITLE
build tagに対応、wasmtime対応

### DIFF
--- a/exec_if.go
+++ b/exec_if.go
@@ -22,10 +22,10 @@ type SrvConfig struct {
 	Addr    string `short:"l" long:"listen" default:"localhost:"`
 	Proto   string `long:"protocol" default:"tcp"`
 	Prefix  string `short:"p" long:"prefix" default:"/"`
-	BaseDir string `short:"b" long:"base-dir"`
+	BaseDir string `short:"b" long:"base-dir" default:"."`
 	Suffix  string `short:"s" long:"suffix"`
 	JSONLog bool   `long:"json-log"`
-	Wasm    bool   `long:"wasm"`
+	Runner  string `long:"runner" default:"os"`
 }
 
 // Runner is interface to run CGI

--- a/exec_os.go
+++ b/exec_os.go
@@ -63,3 +63,9 @@ func (runner *OsRunner) Run(conf SrvConfig, cmdname string, envvar map[string]st
 	cmdStderr.Close()
 	return nil
 }
+
+func init() {
+	runnerMap["os"] = func(SrvConfig) Runner {
+		return &OsRunner{}
+	}
+}

--- a/exec_wasmer.go
+++ b/exec_wasmer.go
@@ -1,3 +1,6 @@
+//go:build wasmer
+// +build wasmer
+
 package main
 
 import (
@@ -70,6 +73,7 @@ func (runner *WasmerRunner) Run(conf SrvConfig, cmdname string, envvar map[strin
 		slog.Error("wasmer module", err)
 		return err
 	}
+	slog.Debug("wasi", "version", wasmer.GetWasiVersion(module).String())
 	importObj, err := wasiEnv.GenerateImportObject(store, module)
 	if err != nil {
 		slog.Error("import object", err)
@@ -102,4 +106,10 @@ func (runner *WasmerRunner) Run(conf SrvConfig, cmdname string, envvar map[strin
 		slog.Debug("wasi success(empty)")
 	}
 	return nil
+}
+
+func init() {
+	runnerMap["wasmer"] = func(SrvConfig) Runner {
+		return &WasmerRunner{}
+	}
 }

--- a/exec_wasmtime.go
+++ b/exec_wasmtime.go
@@ -1,0 +1,119 @@
+//go:build wasmtime
+// +build wasmtime
+
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/bytecodealliance/wasmtime-go"
+	"golang.org/x/exp/slog"
+)
+
+// WasmtimeRunner implements CGI Runner execute by wasmtime
+type WasmtimeRunner struct {
+}
+
+// Run implements Runner.Run
+func (runner WasmtimeRunner) Run(conf SrvConfig, cmdname string, envvar map[string]string,
+	stdin io.ReadCloser, stdout io.Writer, stderr io.Writer) error {
+	fn := filepath.Join(conf.BaseDir, cmdname)
+	bytecode, err := os.ReadFile(fn)
+	if err != nil {
+		slog.Error("read bytecode", err, "filename", fn)
+		return err
+	}
+	slog.Debug("bytecode read", "length", len(bytecode), "filename", fn)
+	engine := wasmtime.NewEngine()
+	module, err := wasmtime.NewModule(engine, bytecode)
+	if err != nil {
+		slog.Error("wasmtime module", err)
+		return err
+	}
+	linker := wasmtime.NewLinker(engine)
+	err = linker.DefineWasi()
+	if err != nil {
+		slog.Error("define wasi", err)
+		return err
+	}
+	wasiConfig := wasmtime.NewWasiConfig()
+	keys := []string{}
+	vals := []string{}
+	for k, v := range envvar {
+		keys = append(keys, k)
+		vals = append(vals, v)
+	}
+	wasiConfig.SetEnv(keys, vals)
+	dir, err := os.MkdirTemp("", "out")
+	if err != nil {
+		slog.Error("mkdtemp", err)
+		return err
+	}
+	defer os.RemoveAll(dir)
+	slog.Debug("tmp dir", "dir", dir)
+	stdoutPath := filepath.Join(dir, "stdout")
+	stderrPath := filepath.Join(dir, "stderr")
+	stdinPath := filepath.Join(dir, "stdin")
+	stdinFp, err := os.OpenFile(stdinPath, os.O_WRONLY|os.O_CREATE, 0755)
+	if err != nil {
+		slog.Error("open stdin", err)
+		return err
+	}
+	io.Copy(stdinFp, stdin)
+	err = stdinFp.Close()
+	if err != nil {
+		slog.Error("stdin close", err)
+		return err
+	}
+	wasiConfig.SetStdinFile(stdinPath)
+	wasiConfig.SetStdoutFile(stdoutPath)
+	wasiConfig.SetStderrFile(stderrPath)
+	store := wasmtime.NewStore(engine)
+	store.SetWasi(wasiConfig)
+	instance, err := linker.Instantiate(store, module)
+	if err != nil {
+		slog.Error("wasmtime instantiate", err)
+		return err
+	}
+	cgi := instance.GetFunc(store, "_start")
+	res, err := cgi.Call(store)
+	if err != nil {
+		slog.Error("wasmtime run", err)
+	}
+	if res != nil {
+		slog.Debug("result", "res", res)
+	} else {
+		slog.Debug("result(nil)")
+	}
+	stdoutContent, err := os.ReadFile(stdoutPath)
+	if err != nil {
+		slog.Error("reading stdout", err)
+		return err
+	}
+	cnt, err := stdout.Write(stdoutContent)
+	if err != nil {
+		slog.Error("writing stdout", err)
+	} else {
+		slog.Debug("stdout", "cnt", cnt)
+	}
+	stderrContent, err := os.ReadFile(stderrPath)
+	if err != nil {
+		slog.Error("reading stderr", err)
+	} else if len(stderrContent) != 0 {
+		cnt, err := stderr.Write(stderrContent)
+		if err != nil {
+			slog.Error("writing stderr", err, "content", string(stderrContent))
+		} else {
+			slog.Debug("stderr", "cnt", cnt, "content", string(stderrContent))
+		}
+	}
+	return nil
+}
+
+func init() {
+	runnerMap["wasmtime"] = func(SrvConfig) Runner {
+		return WasmtimeRunner{}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/wtnb75/httpcgi
 go 1.19
 
 require (
+	github.com/bytecodealliance/wasmtime-go v1.0.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/wasmerio/wasmer-go v1.0.4
 	golang.org/x/exp v0.0.0-20230129154200-a960b3787bd2

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,14 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/bytecodealliance/wasmtime-go v1.0.0 h1:9u9gqaUiaJeN5IoD1L7egD8atOnTGyJcNp8BhkL9cUU=
+github.com/bytecodealliance/wasmtime-go v1.0.0/go.mod h1:jjlqQbWUfVSbehpErw3UoWFndBXRRMvfikYH6KsCwOg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=
 github.com/wasmerio/wasmer-go v1.0.4/go.mod h1:0gzVdSfg6pysA6QVp6iVRPTagC6Wq9pOE8J86WKb2Fk=
 golang.org/x/exp v0.0.0-20230129154200-a960b3787bd2 h1:5sPMf9HJXrvBWIamTw+rTST0bZ3Mho2n1p58M0+W99c=
@@ -15,5 +17,5 @@ golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
- wasmtimeに対応した
- wasmtimeとwasmerを一緒にビルドすると干渉する？
    - wasmer側が動かなくなるため、ビルドタグを使ってビルドを分ける感じにしてみた

副作用だが、OsRunnerだけならgoreleaserでリリースできるな…