### PR TITLE
chore: bootstrap re-pin onto goupdate v1.0.1 (pinact composite)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-    - uses: wtnb75/actions/golang@e91993ee54862b807c74f88477c8818b6c300d5b # v1.0.0
-    - uses: wtnb75/actions/gotest@e91993ee54862b807c74f88477c8818b6c300d5b # v1.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: wtnb75/actions/golang@c8b58e5645e428251cf0abb07b3aee3287409965 # v1.0.1
+    - uses: wtnb75/actions/gotest@c8b58e5645e428251cf0abb07b3aee3287409965 # v1.0.1
       with:
         tags: "wasmer wasmtime docker wazero"
 
@@ -24,8 +24,8 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-    - uses: wtnb75/actions/docker@e91993ee54862b807c74f88477c8818b6c300d5b # v1.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: wtnb75/actions/docker@c8b58e5645e428251cf0abb07b3aee3287409965 # v1.0.1
       with:
         push: 'true'
         context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -22,7 +22,7 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ github.token }}
-    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: stable
         cache: true

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -11,8 +11,8 @@ jobs:
   update-deps:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-    - uses: wtnb75/actions/golang@e91993ee54862b807c74f88477c8818b6c300d5b # v1.0.0
-    - uses: wtnb75/actions/goupdate@e91993ee54862b807c74f88477c8818b6c300d5b # v1.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: wtnb75/actions/golang@c8b58e5645e428251cf0abb07b3aee3287409965 # v1.0.1
+    - uses: wtnb75/actions/goupdate@c8b58e5645e428251cf0abb07b3aee3287409965 # v1.0.1
       with:
         go-test-args: "-v ./..."


### PR DESCRIPTION
## Summary
`wtnb75/actions` の `v1` が新しいcommitに移動しました(`pinact` composite actionを新設し、`goupdate`から呼び出すように — [wtnb75/actions#41](https://github.com/wtnb75/actions/pull/41))。

このリポジトリは既にpinactで具体的なSHAに固定されていた(`@v1`のような浮動参照ではない)ため、新しい`goupdate`(pinactを内部で呼ぶようになったもの)を拾うには一度手動での再pinが必要でした。

このPR以降は、`update-deps.yml`実行時に`goupdate`自体がpinactを呼ぶようになるため、このリポジトリのaction参照は依存更新PRの度に自動的に最新pinへ更新されます(このブートストラップは今回限りの一度きりの作業です)。

## Test plan
- [x] `ci.yml`が実CIでgreen

🤖 Generated with [Claude Code](https://claude.com/claude-code)