### PR TITLE
Rename workflows to branch/main/tag naming convention

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,7 +1,8 @@
-name: ci
+name: branch
 
 on:
-  push: {}
+  push:
+    branches-ignore: [main]
   workflow_dispatch: {}
 
 permissions:
@@ -12,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - uses: wtnb75/actions/golang@c1711251ea69e3e6d68db7a9fa019d79b497f70c # v1.0.3
-    - uses: wtnb75/actions/gotest@c1711251ea69e3e6d68db7a9fa019d79b497f70c # v1.0.3
+    - uses: wtnb75/actions/golang@v1
+    - uses: wtnb75/actions/gotest@v1
       with:
         tags: "wasmer wasmtime docker wazero"
 
@@ -25,7 +26,7 @@ jobs:
       packages: write
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - uses: wtnb75/actions/docker@c1711251ea69e3e6d68db7a9fa019d79b497f70c # v1.0.3
+    - uses: wtnb75/actions/docker@v1
       with:
         push: 'true'
         context: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,58 @@
+name: main
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: wtnb75/actions/golang@v1
+    - uses: wtnb75/actions/gotest@v1
+      with:
+        tags: "wasmer wasmtime docker wazero"
+        html-output-dir: coverage
+    - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      with:
+        enable-cache: false
+    - uses: wtnb75/actions/merge-pages@v1
+      with:
+        dirs: "coverage"
+    - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+  docker:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: wtnb75/actions/docker@v1
+      with:
+        push: 'true'
+        context: .
+        file: Dockerfile.branch
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+  deploy:
+    needs: build
+    if: github.ref_name == 'main'
+    permissions:
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: deploy pages
+      id: deployment
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,4 +1,4 @@
-name: release
+name: tag
 
 on:
   push:


### PR DESCRIPTION
## Summary

Aligns this repo's GitHub Actions workflow naming with the convention already used across the account (Python/TypeScript/Rust/Dart-Flutter phases, and `wtnb75/intarray`):

- `ci.yml` -> `branch.yml`: trigger changed from `push: {}` to `push: {branches-ignore: [main]}` + `workflow_dispatch`. Floating `wtnb75/actions/*@v1` refs used instead of hand-pinned SHAs (matches the established convention for newly-authored workflow files; pinning is handled later by the repo owner's own `pinact run -u` tooling). Job content (test + docker) otherwise unchanged, including this repo's multi-backend `gotest` `tags: "wasmer wasmtime docker wazero"` input.
- New `main.yml`: runs the same test+docker jobs on push to `main`, plus a coverage-to-GitHub-Pages publish step (`gotest` with `html-output-dir: coverage` -> `merge-pages` -> `configure-pages` -> `deploy-pages`).
- `release.yml` -> `tag.yml`: only the `name:` changed, trigger (`push: tags: v*`) and all steps/pins untouched.
- `update-deps.yml`: untouched, already correctly named.

## Known precondition for `main.yml`

`main.yml`'s `gotest` step uses a new `html-output-dir` input that only exists in [`wtnb75/actions#61`](https://github.com/wtnb75/actions/pull/61), which is **not yet merged**. The currently-tagged `v1` of `wtnb75/actions/gotest` only declares a `tags` input, so `main.yml` will fail with an "Unexpected input(s)" validation error on its `gotest` step until #61 merges and `v1` is retagged. `branch.yml` does not depend on this and is unaffected.

Note: GitHub only allows `workflow_dispatch` for workflow files already present on the default branch, so `main.yml` can't be manually triggered from this branch to demonstrate the failure directly — the `gotest@v1` action.yml was checked directly to confirm it will fail as described.

GitHub Pages is already configured for this repo (Settings show `build_type: workflow`, source branch `main`) — no manual Pages setup is needed for `main.yml`'s `deploy` job once it can run successfully.

## Test plan

- [x] `branch.yml` ran on real CI on this branch and passed (test + docker jobs both green).
- [ ] `main.yml` will go green once `wtnb75/actions#61` merges and `v1` is retagged.
- [x] `tag.yml` content verified byte-identical to old `release.yml` except the `name:` field.