### PR TITLE
goreleaser: inject version/commit/date via ldflags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,10 @@ builds:
     goarch:
     - amd64
     - arm64
+    ldflags:
+    - -X main.version={{ .Version }}
+    - -X main.commit={{ .ShortCommit }}
+    - -X main.date={{ .Date }}
 
 dockers:
   - image_templates:


### PR DESCRIPTION
## Background
`main.go` declares `version`/`commit`/`date` vars used by the `--version` flag, but `.goreleaser.yaml` never set them via `ldflags`. As a result, tagged releases always printed `httpcgi version dev commit none build unknown` regardless of the actual release tag.

## Fix
Add the standard `-X main.version={{ .Version }} -X main.commit={{ .ShortCommit }} -X main.date={{ .Date }}` ldflags to the build, matching the pattern already used by `gilterweb`.

## Verification
- `goreleaser build --snapshot --clean --single-target` locally: binary now reports `httpcgi version 0.0.24-SNAPSHOT-<sha> commit <sha> build <timestamp>` instead of `dev`/`none`/`unknown`.
- `branch` workflow green on this branch (build/docker unaffected): https://github.com/wtnb75/httpcgi/actions/runs/30809668685
- Full `tag.yml` release-path verification requires an actual `v*` tag push, left for a real release per project convention.