### PR TITLE
Add fix.yml workflow (go fix + PR)

### DIFF
--- a/.github/workflows/fix.yml
+++ b/.github/workflows/fix.yml
@@ -1,0 +1,18 @@
+name: fix
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: wtnb75/actions/golang@v1
+    - uses: wtnb75/actions/gofix@v1
+      with:
+        go-test-args: "-v ./..."


### PR DESCRIPTION
## Summary
- `wtnb75/actions/gofix@v1` を呼ぶ `fix.yml` (workflow_dispatch限定) を追加。
  `update-deps.yml` と同じ構造 (`golang@v1` → `gofix@v1`)。

## Note
`workflow_dispatch` 限定のワークフローは `main` にマージされるまで dispatch できない
制約があるため、実行確認はマージ後に別途行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)