### PR TITLE
Remove redundant setup-uv step before merge-pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,6 @@ jobs:
       with:
         tags: "wasmer wasmtime docker wazero"
         html-output-dir: coverage
-    - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-      with:
-        enable-cache: false
     - uses: wtnb75/actions/merge-pages@v1
       with:
         dirs: "coverage"


### PR DESCRIPTION
merge-pages now sets up uv internally (wtnb75/actions#79), so this repo's explicit `astral-sh/setup-uv` step — which existed only to satisfy merge-pages — is removed.

## Test plan
- [ ] CI on `main.yml` (build job with merge-pages)